### PR TITLE
openshift templates to support prometheus scraping

### DIFF
--- a/openshift/cvexporter.servicemonitor.yml
+++ b/openshift/cvexporter.servicemonitor.yml
@@ -1,0 +1,34 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: cvexporter-monitoring
+objects:
+- apiVersion: monitoring.coreos.com/v1
+  kind: ServiceMonitor
+  metadata:
+    labels:
+      prometheus: ${PROMINSTANCE}
+    name: cvexporter-service-monitor
+  spec:
+    endpoints:
+    - interval: 60s
+      path: /metrics
+      port: metrics
+      scheme: http
+    namespaceSelector:
+      matchNames:
+      - ${TARGETNS}
+    selector:
+      matchLabels:
+        app: cvexporter
+        port: metrics
+parameters:                                                                     
+- name: PROMINSTANCE
+  value: "app-sre"
+  displayName: prometheus instance for this cluster
+  description: prometheus instance for this cluster, defaults to app-sre
+- name: TARGETNS
+  value: "cvexporter"
+  displayName: target namespace cvexporter lives in
+  description: target namespace cvexporter lvies in, default "cvexporter"
+

--- a/openshift/cvexporter.yaml
+++ b/openshift/cvexporter.yaml
@@ -77,12 +77,13 @@ objects:
   metadata:
     labels:
       app: cvexporter
-    name: cvexporter
+      port: metrics
+    name: cvexporter-metrics
   spec:
     ports:
-    - name: cvexporter-http
+    - name: metrics
       protocol: TCP
-      port: 80
+      port: 8080
       targetPort: 8080
     selector:
       deployment: cvexporter

--- a/openshift/observability-allow.networkpolicy.yaml
+++ b/openshift/observability-allow.networkpolicy.yaml
@@ -1,0 +1,25 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: observability-allow
+objects:
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    annotations:
+    generation: 3
+    name: allow-from-observability-namespace
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            name: ${OBS_NAMESPACE}
+    podSelector: {}
+    policyTypes:
+    - Ingress
+parameters:                                                                     
+- name: OBS_NAMESPACE
+  value: observability
+  displayName: observability namespace
+  description: observability namespace source to allow on ingress policy


### PR DESCRIPTION
added templates for serviceMonitor -- needed for prometheus operator, and networkPolicy -- needed so that if (usually) prometheus runs in a different namespace on the same cluster, it can have access to this ns without needing to stand up a public route